### PR TITLE
Unitテストを導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 # Go workspace file
 go.work
 go.work.sum
+
+# Generated files
+mock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.formatOnSave": true,
+  "[go]": {
+    "editor.defaultFormatter": "golang.go"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # maptalk
+
+## Quick Start
+
+```console
+go run cmd/maptalk/main.go
+```
+
+## Tedt
+
+```console
+go generate ./...
+```
+
+```console
+go test ./...
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 go run cmd/maptalk/main.go
 ```
 
-## Tedt
+## Test
 
 ```console
 go generate ./...

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module maptalk
 
 go 1.22.4
 
-require github.com/labstack/echo/v4 v4.12.0
+require (
+	github.com/labstack/echo/v4 v4.12.0
+	go.uber.org/mock v0.4.0
+)
 
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
+go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
 golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=

--- a/internal/domain/usecase/port/user_usecase_port.go
+++ b/internal/domain/usecase/port/user_usecase_port.go
@@ -1,0 +1,28 @@
+package port
+
+//go:generate mockgen -source=$GOFILE -destination=../../../../mock/mock_$GOFILE -package=mock -self_package=maptalk/mock
+
+// Controller
+type UserInput interface {
+	GetUserByID(id string) (UserOutputData, error)
+}
+
+// Presenter
+type UserOutputData struct {
+	ID   string
+	Name string
+}
+
+type UserOutput interface {
+	PresentUser(user UserData) (UserOutputData, error)
+}
+
+// Repository
+type UserData struct {
+	ID   string
+	Name string
+}
+
+type UserDataAccess interface {
+	FindByID(id string) (UserData, error)
+}

--- a/internal/domain/usecase/user_usecase.go
+++ b/internal/domain/usecase/user_usecase.go
@@ -2,60 +2,30 @@ package usecase
 
 import (
 	"maptalk/internal/domain/entity"
+	"maptalk/internal/domain/usecase/port"
 )
-
-// Controller
-type UserInputPort interface {
-	GetUserByID(id string) (*UserOutputData, error)
-}
-
-// Presenter
-type UserOutputData struct {
-    ID   string
-    Name string
-}
-
-type UserOutputPort interface {
-    PresentUser(user *UserData) (*UserOutputData, error)
-}
-
-// Repository
-type UserData struct {
-    ID   string
-    Name string
-}
-
-type UserDataAccess interface {
-    FindByID(id string) (*UserData, error)
-}
 
 // UseCase
 type userUseCase struct {
-	outputPort UserOutputPort
-    dataAccess UserDataAccess
+	outputPort port.UserOutput
+	dataAccess port.UserDataAccess
 }
 
-func NewUserUseCase(outputPort UserOutputPort, dataAccess UserDataAccess) UserInputPort {
+func NewUserUseCase(outputPort port.UserOutput, dataAccess port.UserDataAccess) port.UserInput {
 	return &userUseCase{
-        outputPort: outputPort,
-        dataAccess: dataAccess,
-    }
+		outputPort: outputPort,
+		dataAccess: dataAccess,
+	}
 }
-func (u *userUseCase) GetUserByID(id string) (*UserOutputData, error) {
+func (u *userUseCase) GetUserByID(id string) (port.UserOutputData, error) {
 	userData, err := u.dataAccess.FindByID(id)
-    if err != nil {
-        return nil, err
-    }
-    // Convert user data to domain entity
-    userEntity := &entity.User{
-        ID:   userData.ID,
-        Name: userData.Name,
-    }
-    // Convert domain entity to user data
-    userData = &UserData{
-        ID:   userEntity.ID,
-        Name: userEntity.Name,
-    }
+	if err != nil {
+		return port.UserOutputData{}, err
+	}
+	// Convert user data to domain entity
+	userEntity := entity.User(userData)
+	// Convert domain entity to user data
+	userData = port.UserData(userEntity)
 
-   return u.outputPort.PresentUser(userData)
+	return u.outputPort.PresentUser(userData)
 }

--- a/internal/domain/usecase/user_usecase_test.go
+++ b/internal/domain/usecase/user_usecase_test.go
@@ -1,0 +1,40 @@
+package usecase
+
+import (
+	"testing"
+
+	"maptalk/internal/domain/usecase/port"
+	"maptalk/mock"
+
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetUserByID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	r := mock.NewMockUserDataAccess(ctrl)
+	r.EXPECT().FindByID("1").Return(port.UserData{
+		ID:   "1",
+		Name: "John Doe",
+	}, nil)
+
+	p := mock.NewMockUserOutput(ctrl)
+	p.EXPECT().PresentUser(port.UserData{
+		ID:   "1",
+		Name: "John Doe",
+	}).Return(port.UserOutputData{
+		ID:   "1",
+		Name: "John Doe",
+	}, nil)
+
+	u := NewUserUseCase(p, r)
+	got, err := u.GetUserByID("1")
+	want := port.UserOutputData{
+		ID:   "1",
+		Name: "John Doe",
+	}
+	if got != want || err != nil {
+		t.Errorf("GetUserByID() = %v, %v, want match for %v, nil", got, err, want)
+	}
+}

--- a/internal/interface/controller/user_controller.go
+++ b/internal/interface/controller/user_controller.go
@@ -2,23 +2,24 @@ package controller
 
 import (
 	"maptalk/internal/domain/usecase"
+	"maptalk/internal/domain/usecase/port"
 )
 
 type UserController struct {
-	userUseCase usecase.UserInputPort
+	userUseCase port.UserInput
 }
 
-func NewUserController(presenter usecase.UserOutputPort, repository usecase.UserDataAccess) *UserController {
+func NewUserController(presenter port.UserOutput, repository port.UserDataAccess) *UserController {
 	u := usecase.NewUserUseCase(presenter, repository)
 	return &UserController{
 		userUseCase: u,
 	}
 }
 
-func (c *UserController) GetUserByID(id string) (*usecase.UserOutputData, error) {
+func (c *UserController) GetUserByID(id string) (port.UserOutputData, error) {
 	user, err := c.userUseCase.GetUserByID(id)
 	if err != nil {
-		return nil, err
+		return port.UserOutputData{}, err
 	}
 	return user, nil
 }

--- a/internal/interface/controller/user_controller_test.go
+++ b/internal/interface/controller/user_controller_test.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"maptalk/internal/domain/usecase/port"
+	"testing"
+
+	"maptalk/mock"
+
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetUserByID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	r := mock.NewMockUserDataAccess(ctrl)
+	r.EXPECT().FindByID("1").Return(port.UserData{
+		ID:   "1",
+		Name: "John Doe",
+	}, nil)
+
+	p := mock.NewMockUserOutput(ctrl)
+	p.EXPECT().PresentUser(port.UserData{
+		ID:   "1",
+		Name: "John Doe",
+	}).Return(port.UserOutputData{
+		ID:   "1",
+		Name: "John Doe",
+	}, nil)
+
+	c := NewUserController(p, r)
+	got, err := c.GetUserByID("1")
+	want := port.UserOutputData{
+		ID:   "1",
+		Name: "John Doe",
+	}
+	if got != want || err != nil {
+		t.Errorf("GetUserByID() = %v, %v, want match for %v, nil", got, err, want)
+	}
+}

--- a/internal/interface/presenter/user_presenter.go
+++ b/internal/interface/presenter/user_presenter.go
@@ -1,20 +1,17 @@
 package presenter
 
 import (
-	"maptalk/internal/domain/usecase"
+	"maptalk/internal/domain/usecase/port"
 )
 
 type userPresenter struct {
 }
 
-func NewUserPresenter() usecase.UserOutputPort {
+func NewUserPresenter() port.UserOutput {
 	return &userPresenter{}
 }
 
-func (p *userPresenter) PresentUser(user *usecase.UserData) (*usecase.UserOutputData, error)  {
-	userOutputData := &usecase.UserOutputData{
-		ID:   user.ID,
-		Name: user.Name,
-	}
+func (p *userPresenter) PresentUser(user port.UserData) (port.UserOutputData, error) {
+	userOutputData := port.UserOutputData(user)
 	return userOutputData, nil
 }

--- a/internal/interface/presenter/user_presenter_test.go
+++ b/internal/interface/presenter/user_presenter_test.go
@@ -1,0 +1,22 @@
+package presenter
+
+import (
+	"maptalk/internal/domain/usecase/port"
+	"testing"
+)
+
+func TestPresentUser(t *testing.T) {
+	user := port.UserData{
+		ID:   "1",
+		Name: "test",
+	}
+	p := NewUserPresenter()
+	got, err := p.PresentUser(user)
+	want := port.UserOutputData{
+		ID:   "1",
+		Name: "test",
+	}
+	if got != want || err != nil {
+		t.Errorf("PresentUser() = %v, %v, want match for %v, nil", got, err, want)
+	}
+}

--- a/internal/interface/repository/user_repository.go
+++ b/internal/interface/repository/user_repository.go
@@ -1,21 +1,20 @@
 package repository
 
 import (
-	"maptalk/internal/domain/usecase"
+	"maptalk/internal/domain/usecase/port"
 )
-
 
 type userRepository struct{}
 
-func NewUserRepository() usecase.UserDataAccess {
+func NewUserRepository() port.UserDataAccess {
 	return &userRepository{}
 }
 
-func (p *userRepository) FindByID(id string) (*usecase.UserData, error) {
-    // dummy data
-    user := &usecase.UserData{
-        ID:   id,
-        Name: "John Doe",
-    }
-    return user, nil
+func (p *userRepository) FindByID(id string) (port.UserData, error) {
+	// dummy data
+	user := port.UserData{
+		ID:   id,
+		Name: "John Doe",
+	}
+	return user, nil
 }

--- a/internal/interface/repository/user_repository_test.go
+++ b/internal/interface/repository/user_repository_test.go
@@ -1,0 +1,18 @@
+package repository
+
+import (
+	"maptalk/internal/domain/usecase/port"
+	"testing"
+)
+
+func TestFindById(t *testing.T) {
+	r := NewUserRepository()
+	got, err := r.FindByID("1")
+	want := port.UserData{
+		ID:   "1",
+		Name: "John Doe",
+	}
+	if got != want || err != nil {
+		t.Errorf("FindByID() = %v, %v, want match for %v, nil", got, err, want)
+	}
+}


### PR DESCRIPTION
## やったこと
- `go test ./...`でテストが動くように整備
  - 単体で実行できるようにモック
    - go.uber.org/mockを追加
    - モック利用でテストコードがimport cycleになるため、usecaseのinterfaceをportとして切り出し
- 不要な参照渡しを修正
- 保存時にコードを自動整形

## テストの実行方法
1. モックコードの生成
  ``` console
  go generate ./...
  ```
2. テストの実行
  ```console
  go test ./...
  ```